### PR TITLE
Adding a permissions check to api to exclude not on web

### DIFF
--- a/arches_keep_app/views/keep.py
+++ b/arches_keep_app/views/keep.py
@@ -106,6 +106,8 @@ class ChangesView(View):
         #Data
         db_data = get_data(from_date, to_date, per_page, page)
 
+        #TODO: for version 7.6 this should be changed to look at a Not on Web Group rather than relying on user permissions
+
         permissions = UserObjectPermission.objects.filter(permission__codename="no_access_to_resourceinstance").values("object_pk")
         no_access_list = [permission['object_pk'] for permission in permissions]
 

--- a/arches_keep_app/views/keep.py
+++ b/arches_keep_app/views/keep.py
@@ -16,6 +16,8 @@ from arches.app.models.models import Concept as modelConcept
 from arches.app.models.concept import Concept
 from arches.app.utils.skos import SKOSWriter, SKOSReader
 
+from guardian.models import UserObjectPermission
+
 from arches import __version__
 
 #Decorators
@@ -104,7 +106,12 @@ class ChangesView(View):
         #Data
         db_data = get_data(from_date, to_date, per_page, page)
 
-        json_data = download_data(db_data[0])
+        permissions = UserObjectPermission.objects.filter(permission__codename="no_access_to_resourceinstance").values("object_pk")
+        no_access_list = [permission['object_pk'] for permission in permissions]
+
+        filtered_data = [latest_edit for latest_edit in db_data[0] if latest_edit.resourceinstanceid not in no_access_list] 
+
+        json_data = download_data(filtered_data)
 
         end_time = time()
 


### PR DESCRIPTION
I've used the ORM to check UserObjectPermission and create a list of all resources with a "no_access_to_resourceinstance" permission. Technically this could just be anyone with access restricted, rather than anonymous (user 2), but should identify the right resources for our purposes. 

The data is then filtered to exclude these resources, before being passed to the download_data function. 